### PR TITLE
Export oft-used types w/o exposing implementation

### DIFF
--- a/lib/stdlib/src/ets.erl
+++ b/lib/stdlib/src/ets.erl
@@ -43,7 +43,7 @@
 
 -export([i/0, i/1, i/2, i/3]).
 
--export_type([tab/0, tid/0, match_spec/0, comp_match_spec/0, match_pattern/0]).
+-export_type([tab/0, tid/0, type/0, match_spec/0, comp_match_spec/0, match_pattern/0]).
 
 %%-----------------------------------------------------------------------------
 

--- a/lib/stdlib/src/supervisor.erl
+++ b/lib/stdlib/src/supervisor.erl
@@ -55,9 +55,10 @@
 
 %%--------------------------------------------------------------------------
 
--export_type([sup_flags/0, child_spec/0, strategy/0,
-              startchild_ret/0, startchild_err/0,
-              startlink_ret/0, startlink_err/0]).
+-export_type([sup_flags/0, child_spec/0, mfargs/0,
+              restart/0, strategy/0, startchild_ret/0,
+              startchild_err/0, startlink_ret/0, startlink_err/0,
+              shutdown/0]).
 
 %%--------------------------------------------------------------------------
 


### PR DESCRIPTION
Export more types that meet these criteria:

- Documented
- Convenient for client code. They are already
used in specs of public functions of their respective
modules.
- These types do not expose implementation details.

The types are:

ets.erl:
- type() :: set | ordered_set | bag | duplicate_bag.

re.erl:
- mp() :: {re_pattern,_ ,_ ,_ ,_ }.*

supervisor.erl:
- `restart() :: 'permanent' | 'transient' | 'temporary'
- `mfargs() :: {M :: module(), F :: atom(), A :: [term()]
   | undefined}.`
- `shutdown() :: 'brutal_kill' | timeout().`

The reason for this change is to fix the status quo, which is
that teams either must:
- copy/pasta the types into client code, leading to code bloat and having
to manually keep the types in sync.
- OR refer to non-exported types, which will mean either more noise
or less accuracy from code analysis tools. For example,
Dialyzer will either warn or treat the types as `term()`.